### PR TITLE
Remove extra params

### DIFF
--- a/example/23.html
+++ b/example/23.html
@@ -11,7 +11,7 @@ var data = d3.range(20).map(function(it) {
     category: "ABC".charAt(parseInt(Math.random() * 3))
   };
 });
-var entries = d3.nest().key(function(it) { return it.category; }).entries(data,d3.map);
+var entries = d3.nest().key(function(it) { return it.category; }).entries(data);
 var root = {values: entries};
 var nodes = d3.layout.pack()
    .size([800, 400])


### PR DESCRIPTION
`nest.entries` does not have second arg.

Ref: https://github.com/mbostock/d3/wiki/Arrays#nest_entries

有同學看很細，問為什麼 .entries 有第二個引數，但其實不該有。